### PR TITLE
Add links to README bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Implicit gender bias in evaluations negatively impacts women at every stage of her career. The goal of this project is to create a web-based text analysis tool that scans and reveals language bias associated with evaluations and letters of recommendation written for trainees and applicants.  The tool will provide a summary of potential changes to the writer to help them remove bias.  The hope is that by bringing awareness to the existence of implicit bias, we can change how evaluations for women are drafted and judged, thereby providing a concrete way to tackle gender disparities.
 
-## Welcome! 
+## Welcome!
 
 Thank you for visiting the Reading for Gender Bias project!
 
@@ -24,8 +24,8 @@ This document (the README file) introduces you to the project.  Feel free to exp
 
 * Gender disparities exist in medicine, science, business, and many other professions
 * Letters of recommendation and evaluations written for women differ in key ways from letters written for men
-* The differences impact everything from how women are graded in a class to whether they are hired or promoted 
-* Most writers (men and women) are unaware of gender bias in their writing 
+* The differences impact everything from how women are graded in a class to whether they are hired or promoted
+* Most writers (men and women) are unaware of gender bias in their writing
 
 So, even if someone wants to write a really strong letter for a woman, they will probably include language that reflects [implicit bias][link_implicitbias], which weakens the letter.
 
@@ -66,14 +66,14 @@ If you want to report a problem or suggest an improvement, please [open an issue
 
 Studies on gender bias show that letters/evaluations written for women are:
 
-* Less likely to mention [publications, projects, and research](#publications-projects-and-research) 
+* Less likely to mention [publications, projects, and research](#publications-projects-and-research)
 * Less likely to include [superlatives](#superlatives) ('She was the best, the top, the greatest')
 * Less likely to use [nouns](#nouns) ('He was a researcher' while 'she taught')
 * More likely to include [minimal assurance](#minimal-assurance) ('She can do the job') rather than a strong endorsement
 * More likely to highlight [effort](#effort) ('She is hard-working') instead of highlighting accomplishments ('her research')
 * More likely to discuss [personal life](#personal-life) and fail to use formal titles
-* More likely to include [gender stereotypes](#gender-stereotypes) ('She is compassionate' while 'he is a leader') and emotion-focused words 
-* More likely to [raise doubt](#raise-doubt) 
+* More likely to include [gender stereotypes](#gender-stereotypes) ('She is compassionate' while 'he is a leader') and emotion-focused words
+* More likely to [raise doubt](#raise-doubt)
 * [Shorter](#shorter)
 
 
@@ -82,45 +82,45 @@ Studies on gender bias show that letters/evaluations written for women are:
 ## References
 
 ### Publications, Projects, and Research
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
 ### Superlatives
-* Dutt, K., Pfaff, D. L., Bernstein, A. F., Dillard, J. S., & Block, C. J. (2016). Gender differences in recommendation letters for postdoctoral fellowships in geoscience. Nature Geoscience, 9(11), 805.
-* Schmader, T., Whitehead, J., & Wysocki, V. H. (2007). A linguistic comparison of letters of recommendation for male and female chemistry and biochemistry job applicants. Sex Roles, 57(7-8), 509-514.
+* Dutt, K., Pfaff, D. L., Bernstein, A. F., Dillard, J. S., & Block, C. J. (2016). Gender differences in recommendation letters for postdoctoral fellowships in geoscience. Nature Geoscience, 9(11), 805. [[Link](https://www.nature.com/articles/ngeo2819)]
+* Schmader, T., Whitehead, J., & Wysocki, V. H. (2007). A linguistic comparison of letters of recommendation for male and female chemistry and biochemistry job applicants. Sex Roles, 57(7-8), 509-514. [[Link](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2572075/)] [[PDF](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2572075/pdf/nihms72978.pdf)]
 
 ### Nouns
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
 ### Minimal Assurance
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
-### Effort 
-* Deaux, K. & Emswiller, T., "Explanations of successful performance on sex-linked tasks: What is skill for the male is luck for the female," Journal of Personality and Social Psychology 29(1974): 80-85
-* Steinpreis, R., Anders, K.A., & Ritzke, D., "The impact of gender on the review of the curricula vitae of job applicants and tenure candidates: A national empirical study," Sex Roles 41(1999): 509-528
+### Effort
+* Deaux, K. & Emswiller, T., "Explanations of successful performance on sex-linked tasks: What is skill for the male is luck for the female," Journal of Personality and Social Psychology 29(1974): 80-85 [[Link](http://psycnet.apa.org/record/1974-20859-001)]
+* Steinpreis, R., Anders, K.A., & Ritzke, D., "The impact of gender on the review of the curricula vitae of job applicants and tenure candidates: A national empirical study," Sex Roles 41(1999): 509-528 [[Link](https://link.springer.com/article/10.1023/A:1018839203698)] [[PDF](https://pdfs.semanticscholar.org/bb0f/52062572e83c07b51d3f83ad937633a4637e.pdf)]
 
 ### Personal Life
-* Madera, J. M., Hebl, M. R., & Martin, R. C. (2009). Gender and letters of recommendation for academia: Agentic and communal differences. Journal of Applied Psychology, 94(6), 1591.
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Madera, J. M., Hebl, M. R., & Martin, R. C. (2009). Gender and letters of recommendation for academia: Agentic and communal differences. Journal of Applied Psychology, 94(6), 1591. [[Link](http://psycnet.apa.org/record/2009-21033-018)] [[PDF](https://eswnonline.org/wp-content/uploads/gravity_forms/23-b28d66b6400f67d9648a049f8faf44e0/2015/05/Madera2009_Gender-and-letters-of-recommendation.pdf)]
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
 ### Gender Stereotypes
-* Axelson RD, Solow CM, Ferguson KJ, Cohen MB.  Assessing implicit gender bias in Medical Student Performance Evaluations. Eval Health Prof. 2010 Sep;33(3):365-85.
-* Eagly, A.H.; Karau, S.J., "Role congruity theory of prejudice toward female leaders," Psychological Review 109, no. 3 (July 2002): 573-597.; Ridgeway, 2002.
-* Foschi M. Double standards for competence: theory and research. Ann Rev Soc. 2000;26:21–42. 
-* Gaucher, D., Friesen, J., & Kay, A. C. (2011, March 7). Evidence That Gendered Wording in Job Advertisements Exists and Sustains Gender Inequality. Journal of Personality and Social Psychology. 
-* Hirshfield LE. ‘‘She’s not good with crying’’: the effect of gender expectations on graduate students’ assessments of their principal investigators. Gender Educ. 2014;26(6):601–617. 
-* Madera, J. M., Hebl, M. R., & Martin, R. C. (2009). Gender and letters of recommendation for academia: Agentic and communal differences. Journal of Applied Psychology, 94(6), 1591.
-* Ross DA, Boatright D, Nunez-Smith M, Jordan A, Chekroud A, Moore EZ (2017) Differences in words used to describe racial and gender groups in Medical Student Performance Evaluations. PLoS ONE 12(8): e0181659.
-* Sprague J, Massoni K. Student evaluations and gendered expectations: what we can’t count can hurt us. Sex Roles. 2005;53(11):779–793. 
-* Steinpreis RE, Anders KA, Ritzke D. The impact of gender on the review of the curricula vitae of job applicants and tenure candidates: a national empirical study. Sex Roles. 1999;41(7):509–528. 
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
-* Wenneras C, Wold A. Nepotism and sexism in peer review. Nature. 1997;387(6631):341–343. 
+* Axelson RD, Solow CM, Ferguson KJ, Cohen MB.  Assessing implicit gender bias in Medical Student Performance Evaluations. Eval Health Prof. 2010 Sep;33(3):365-85. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0163278710375097?url_ver=Z39.88-2003&rfr_id=ori:rid:crossref.org&rfr_dat=cr_pub%3dpubmed)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0163278710375097)]
+* Eagly, A.H.; Karau, S.J., "Role congruity theory of prejudice toward female leaders," Psychological Review 109, no. 3 (July 2002): 573-597.; Ridgeway, 2002. [[Link](http://psycnet.apa.org/record/2002-13781-007)] [[PDF](https://www.rci.rutgers.edu/~search1/pdf/Eagley_Role_Conguity_Theory.pdf)]
+* Foschi M. Double standards for competence: theory and research. Ann Rev Soc. 2000;26:21–42. [[Link](http://psycnet.apa.org/record/2000-02783-002)] [[PDF](http://search.committee.module.rutgers.edu/pdf/2787021.pdf)]
+* Gaucher, D., Friesen, J., & Kay, A. C. (2011, March 7). Evidence That Gendered Wording in Job Advertisements Exists and Sustains Gender Inequality. Journal of Personality and Social Psychology. [[Link](http://psycnet.apa.org/record/2011-04642-001)] [[PDF](https://www.sussex.ac.uk/webteam/gateway/file.php?name=gendered-wording-in-job-adverts.pdf&site=7)]
+* Hirshfield LE. ‘‘She’s not good with crying’’: the effect of gender expectations on graduate students’ assessments of their principal investigators. Gender Educ. 2014;26(6):601–617. [[Link](https://www.tandfonline.com/doi/abs/10.1080/09540253.2014.940036)]
+* Madera, J. M., Hebl, M. R., & Martin, R. C. (2009). Gender and letters of recommendation for academia: Agentic and communal differences. Journal of Applied Psychology, 94(6), 1591. [[Link](http://psycnet.apa.org/record/2009-21033-018)] [[PDF](https://eswnonline.org/wp-content/uploads/gravity_forms/23-b28d66b6400f67d9648a049f8faf44e0/2015/05/Madera2009_Gender-and-letters-of-recommendation.pdf)]
+* Ross DA, Boatright D, Nunez-Smith M, Jordan A, Chekroud A, Moore EZ (2017) Differences in words used to describe racial and gender groups in Medical Student Performance Evaluations. PLoS ONE 12(8): e0181659. [[Link](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0181659)] [[PDF](http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.0181659&type=printable)]
+* Sprague J, Massoni K. Student evaluations and gendered expectations: what we can’t count can hurt us. Sex Roles. 2005;53(11):779–793. [[Link](http://psycnet.apa.org/record/2008-14048-001)] [[PDF](https://www.researchgate.net/profile/Joey_Sprague/publication/227320290_Student_Evaluations_and_Gendered_Expectations_What_We_Can%27t_Count_Can_Hurt_Us/links/53dfa71e0cf27a7b83069ecb/Student-Evaluations-and-Gendered-Expectations-What-We-Cant-Count-Can-Hurt-Us.pdf?origin=publication_detail)]
+* Steinpreis RE, Anders KA, Ritzke D. The impact of gender on the review of the curricula vitae of job applicants and tenure candidates: a national empirical study. Sex Roles. 1999;41(7):509–528. [[Link](https://link.springer.com/article/10.1023/A:1018839203698)] [[PDF](https://pdfs.semanticscholar.org/bb0f/52062572e83c07b51d3f83ad937633a4637e.pdf)]
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
+* Wenneras C, Wold A. Nepotism and sexism in peer review. Nature. 1997;387(6631):341–343. [[Link](https://www.nature.com/articles/387341a0)] [[PDF](https://www.cs.utexas.edu/users/mckinley/notes/ww-nature-1997.pdf)]
 
 ### Raise Doubt
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
 ### Shorter
-* Dutt, K., Pfaff, D. L., Bernstein, A. F., Dillard, J. S., & Block, C. J. (2016). Gender differences in recommendation letters for postdoctoral fellowships in geoscience. Nature Geoscience, 9(11), 805.
-* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220.
+* Dutt, K., Pfaff, D. L., Bernstein, A. F., Dillard, J. S., & Block, C. J. (2016). Gender differences in recommendation letters for postdoctoral fellowships in geoscience. Nature Geoscience, 9(11), 805. [[Link](https://www.nature.com/articles/ngeo2819)]
+* Trix, F. & Psenka, C., "Exploring the color of glass: Letters of recommendation for female and male medical faculty," Discourse & Society 14(2003): 191-220. [[Link](http://journals.sagepub.com/doi/abs/10.1177/0957926503014002277)] [[PDF](http://journals.sagepub.com/doi/pdf/10.1177/0957926503014002277)]
 
 [link_implicitbias]: https://en.wikipedia.org/wiki/Implicit_stereotype
 [link_Jason]: https://twitter.com/jaclark


### PR DESCRIPTION
I was really impressed with the list of publications included to delve further into the effects and forms of bias, and I thought it would be helpful for anyone else coming into the project to have easy access to all of those publications. I added a hyperlink to every listing (some are repeats, so it could be a problem if these links go dead later). Where possible, I also included a link to a freely available (and legal) PDF of the publication.