### PR TITLE
Publications and PublicationDetector

### DIFF
--- a/genderbias/publications/__init__.py
+++ b/genderbias/publications/__init__.py
@@ -41,12 +41,9 @@ def identify_publications(doc: Document) -> Dict[str, float]:
     # TODO: Smart quotes and single quotes
     rxp = re.compile('"[^"]+"')
     for match in re.findall(rxp, doc._text):
-        print(match)
         if match not in potential_publications:
             potential_publications[match] = 0.
         potential_publications[match] += 0.25
-
-    print(potential_publications)
 
     return potential_publications
 
@@ -98,8 +95,7 @@ class PublicationDetector(Detector):
         # with a probability of 50%, then we could consider that a mention of
         # one single publication.
         pub_count = sum(identify_publications(doc).values())
-        print(pub_count)
-        if pub_count < 0.5:
+        if pub_count < self.min_publications:
             all_flags.append(Flag(
                 0, 0,
                 Issue(

--- a/tests/test_publication_detector.py
+++ b/tests/test_publication_detector.py
@@ -1,0 +1,26 @@
+from genderbias import Document
+from genderbias.publications import PublicationDetector
+
+BAD_LETTERS = [
+    """
+    NAME is a prolific researcher, and she published 12 papers during her tenure at UNIVERSITY, including some very well-respected articles in our field.
+    """,
+]
+
+GOOD_LETTERS = [
+    """
+    NAME is a prolific researcher, and she published 12 papers during her tenure at UNIVERSITY, including the seminal microbiology paper, "On the Origin of Brie Cheese," and the followup microbotany manuscript, "A Brief History of Thyme."
+    """,
+]
+
+pub_detector = PublicationDetector()
+
+def test_bad_letters_fail():
+    for letter in BAD_LETTERS:
+        doc = Document(letter)
+        assert pub_detector.get_flags(doc)
+
+def test_good_letters_pass():
+    for letter in GOOD_LETTERS:
+        doc = Document(letter)
+        assert len(pub_detector.get_flags(doc)) == 0

--- a/tests/test_publication_detector.py
+++ b/tests/test_publication_detector.py
@@ -24,3 +24,9 @@ def test_good_letters_pass():
     for letter in GOOD_LETTERS:
         doc = Document(letter)
         assert len(pub_detector.get_flags(doc)) == 0
+
+def test_good_letters_fail_high_thresh_detector():
+    picky_detector = PublicationDetector(min_publications=10)
+    for letter in GOOD_LETTERS + BAD_LETTERS:
+        doc = Document(letter)
+        assert picky_detector.get_flags(doc)


### PR DESCRIPTION
Begin to address #4.

This PR begins to implement a detector that looks for publications and names of projects. This is really tricky!

This current implementation only identifies quoted strings as (low-confidence) publications. This is obviously not a great start.

### Possible avenues of investigation:

| Idea | Challenge |
|------|-----------|
| Named-Entity Recognition | Neither nltk nor spacy natively support a "project" or "publication" entity, which means we'll likely have to [train our own NER model](https://spacy.io/usage/linguistic-features#updating). |
| Quoted-Strings | My current implementation. Very low-quality predictions, because any quoted string is considered a low-confidence publication. |
| Crossref Lookup | Looking up any conspicuous strings using the [crossref](https://www.crossref.org/) API will get very slow |

Very interested in hearing thoughts on approach here.

### Implementation:

The `PublicationDetector` looks to find a certain number (caller-customizable; a perfect place for a `Detector`-level parameter!) of publications. Because publication identification is probablistic, this is a net sum of probabilities, not an absolute count. So two 50%-likely publications are equivalent to one for-sure publication.

You can set the minimum required publication count in the detector instantiation:

```python
PublicationDetector(min_publications=5)
```