### PR TITLE
Add Effort/Achievement spacy adjective attribution

### DIFF
--- a/genderbias/effort/__init__.py
+++ b/genderbias/effort/__init__.py
@@ -60,7 +60,7 @@ class EffortDetector(Detector):
         doc = nlp(doc.text())
 
         # Ignore adjectives about the author.
-        _PRONOUNS_TO_IGNORE = ["me", "I", "myself"]
+        _PRONOUNS_TO_IGNORE = ["me", "myself", "I"]
 
         # Keep track of accomplishment- or effort-specific words:
         accomplishment_words = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+spacy>=2.2.0,<3.0.0
+flask
+flask-cors
+nltk
+spacy
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz#egg=en_core_web_sm

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ VERSION = "0.1.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     # TODO: Extend this list as further dependencies are determined
-    'nltk',
+    "nltk",
+    "spacy",
     "flask",
     "flask-cors"
 ]


### PR DESCRIPTION
This begins to address #64 and #8:

This includes the conventional/naïve wordlist check from before, but now also tries to attribute that adjective to a noun/pronoun in the text. If it can find one, it excludes adjectives about a set of excluded pronouns (I, me, myself) so as to avoid the problem in [this comment](https://github.com/gender-bias/gender-bias/issues/8#issuecomment-653241534) where adjectives about the writer are excluded.