### PR TITLE
Silence the STDOUT download-complete text for nltk models

### DIFF
--- a/genderbias/document.py
+++ b/genderbias/document.py
@@ -7,10 +7,9 @@ import os
 import nltk
 
 # Do not print log messages:
-with redirect_stdout(open(os.devnull, "w")):
-    nltk.download("punkt")
-    nltk.download("wordnet")
-    nltk.download("averaged_perceptron_tagger")
+nltk.download("punkt", quiet=True)
+nltk.download("wordnet", quiet=True)
+nltk.download("averaged_perceptron_tagger", quiet=True)
 
 
 def cached(method):


### PR DESCRIPTION
Right now, every time you run the command-line interface (or, less distractingly, the server), the NLTK model downloader prints to stdout. This PR silences that output.