### PR TITLE
Pretty terminal output

### DIFF
--- a/bin/genderbias
+++ b/bin/genderbias
@@ -26,6 +26,16 @@ def main():
         action="store_true",
         help="Enable JSON output, instead of text",
     )
+
+    parser.add_argument(
+        "--no-color",
+        dest="no_color",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Use plaintext output (instead of color + formatting)",
+    )
+
     parser.add_argument(
         "--list-detectors",
         dest="list_detectors",
@@ -69,7 +79,20 @@ def main():
         reports.append(detector().get_report(doc))
 
     if not args.json:
-        print("\n".join(str(report) for report in reports))
+        if args.no_color:
+            print(
+                "\n".join(
+                    report.pprint(use_emoji=False, use_color=False)
+                    for report in reports
+                    if len(report.get_flags())
+                )
+            )
+        else:
+            print(
+                "\n".join(
+                    report.pprint() for report in reports if len(report.get_flags())
+                )
+            )
     else:
         reports_data = [report.to_dict() for report in reports]
         print(json.dumps(reports_data))

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
+from typing import List
 
 from .document import Document
+from .printing import pretty_format, Colors, NoColors
 
 
 class BiasBoundsException(Exception):
@@ -171,6 +173,19 @@ class Report:
         """
         self._flags.append(flag)
 
+    def get_flags(self) -> List[Flag]:
+        """
+        Get a list of flags from this Report.
+
+        Arguments:
+            None
+
+        Returns:
+            List[Flag]
+
+        """
+        return self._flags
+
     def set_summary(self, summary: str) -> None:
         """
         Sets the summary for the report.
@@ -204,6 +219,40 @@ class Report:
         if self._summary:
             text.append(" SUMMARY: " + self._summary)
         return "\n".join(text)
+
+    def pprint(self, use_emoji: bool = True, use_color: bool = True) -> str:
+        """
+        Creates a prettily-printed version of this report, good for CLI output.
+
+        Arguments:
+            use_emoji (bool: True): Whether to print emoji when running output
+            use_color (bool: True): Whether to use color when printing
+
+        Returns:
+            str: A terminal-friendly formatted string for stdout
+
+        """
+        good_indicator = "🟢" if use_emoji else " "
+        bad_indicator = "🔴" if use_emoji else "!"
+
+        color_scheme = Colors if use_color else NoColors
+
+        text_lines = []
+        text_lines.append(
+            pretty_format([color_scheme.BOLD, color_scheme.CYAN], self._name)
+        )
+        for flag in self._flags:
+            if flag.issue.bias > 0:
+                text_lines.append(
+                    f"  {good_indicator}\t"
+                    + pretty_format([color_scheme.GREEN], str(flag))
+                )
+            elif flag.issue.bias <= 0:
+                text_lines.append(
+                    f"  {bad_indicator}\t"
+                    + pretty_format([color_scheme.RED], str(flag))
+                )
+        return "\n".join(text_lines)
 
     def to_dict(self) -> dict:
         """

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -232,8 +232,8 @@ class Report:
             str: A terminal-friendly formatted string for stdout
 
         """
-        good_indicator = "🟢" if use_emoji else " "
-        bad_indicator = "🔴" if use_emoji else "!"
+        good_indicator = " "
+        bad_indicator = "!"
 
         color_scheme = Colors if use_color else NoColors
 

--- a/genderbias/detector.py
+++ b/genderbias/detector.py
@@ -239,7 +239,7 @@ class Report:
 
         text_lines = []
         text_lines.append(
-            pretty_format([color_scheme.BOLD, color_scheme.CYAN], self._name)
+            pretty_format([color_scheme.BOLD], self._name)
         )
         for flag in self._flags:
             if flag.issue.bias > 0:

--- a/genderbias/printing.py
+++ b/genderbias/printing.py
@@ -1,0 +1,48 @@
+# Taken from https://gist.github.com/j6k4m8/24f028250dc38eb8579e4b9090beeeb6
+
+
+class Colors:
+    PURPLE = "\033[95m"
+    CYAN = "\033[96m"
+    DARKCYAN = "\033[36m"
+    BLUE = "\033[94m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
+
+
+class NoColors:
+    PURPLE = ""
+    CYAN = ""
+    DARKCYAN = ""
+    BLUE = ""
+    GREEN = ""
+    YELLOW = ""
+    RED = ""
+    BOLD = ""
+    UNDERLINE = ""
+    END = ""
+
+
+def pretty_print(colors, text, cr=True):
+    if isinstance(colors, list):
+        pre = "".join(colors)
+    else:
+        pre = colors
+
+    if cr:
+        print(pre + text + Colors.END)
+    else:
+        print(pre + text + Colors.END, end="")
+
+
+def pretty_format(colors, text):
+    if isinstance(colors, list):
+        pre = "".join(colors)
+    else:
+        pre = colors
+
+    return pre + text + Colors.END


### PR DESCRIPTION
This PR adds much more readable output to the terminal command-line stdout. 

- [x] Bolding and colors in output (disableable with `--no-color`)
- [x] Emoji in output (disableable with `--no-color`)
- [x] Indented output (to give a clear hierarchy of Report→Flag
- [x] Reports with nothing to say are no longer printed

## Old output:

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/693511/86515794-9ac73e80-bde9-11ea-9342-fc1bbb5b41f3.png">

## New default output:

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/693511/86499839-3c537f00-bd5b-11ea-8b1f-553dff9444c6.png">

## With `--no-color`:

<img width="1358" alt="image" src="https://user-images.githubusercontent.com/693511/86499856-47a6aa80-bd5b-11ea-8de0-89715967d104.png">
